### PR TITLE
Refactor registration and key mirroring

### DIFF
--- a/addon/properties/__init__.py
+++ b/addon/properties/__init__.py
@@ -11,17 +11,23 @@ property_classes = (
     AH_ActionProperties,
 )
 
+# Scene property pointers {"attribute_name": PropertyGroup}
+property_pointers = {
+    "bprops": AH_BakeProperties,
+    "fprops": AH_FacialProperties,
+    "Dprops": AH_ActionProperties,
+}
+
 def register_properties():
     """Register all property groups"""
     from bpy.utils import register_class
-    
+
     for cls in property_classes:
         register_class(cls)
-    
+
     # Register property pointers
-    bpy.types.Scene.bprops = bpy.props.PointerProperty(type=AH_BakeProperties)
-    bpy.types.Scene.fprops = bpy.props.PointerProperty(type=AH_FacialProperties)
-    bpy.types.Scene.Dprops = bpy.props.PointerProperty(type=AH_ActionProperties)
+    for attr, prop_type in property_pointers.items():
+        setattr(bpy.types.Scene, attr, bpy.props.PointerProperty(type=prop_type))
     
     # Add Factor property for decimation
     bpy.types.Scene.Factor = bpy.props.FloatProperty(
@@ -36,9 +42,8 @@ def unregister_properties():
     """Unregister all property groups in reverse order"""
     # Unregister property pointers
     del bpy.types.Scene.Factor
-    del bpy.types.Scene.Dprops
-    del bpy.types.Scene.fprops
-    del bpy.types.Scene.bprops
+    for attr in property_pointers:
+        delattr(bpy.types.Scene, attr)
     
     # Unregister classes
     from bpy.utils import unregister_class

--- a/addon/register/__init__.py
+++ b/addon/register/__init__.py
@@ -1,37 +1,26 @@
-import bpy
+"""Addon registration utilities."""
+
+from importlib import import_module
+
+
+# (module_path, register_func, unregister_func)
+COMPONENTS = [
+    ("..icons", "register_icons", "unregister_icons"),
+    ("..properties", "register_properties", "unregister_properties"),
+    ("..operators", "register_operators", "unregister_operators"),
+    ("..ui", "register_panels", "unregister_panels"),
+]
+
 
 def register_addon():
-    """Register all components of the addon"""
-    # Register icons first
-    from ..icons import register_icons
-    register_icons()
-    
-    # Register properties
-    from ..properties import register_properties
-    register_properties()
-    
-    # Register operators
-    from ..operators import register_operators
-    register_operators()
+    """Register all components of the addon."""
+    for module_name, register_func, _ in COMPONENTS:
+        module = import_module(module_name, __package__)
+        getattr(module, register_func)()
 
-    # Register UI panels
-    from ..ui import register_panels
-    register_panels()
-   
+
 def unregister_addon():
-    """Unregister all components of the addon in reverse order"""
-    # Unregister UI panels first
-    from ..ui import unregister_panels
-    unregister_panels()
-
-    # Unregister operators
-    from ..operators import unregister_operators
-    unregister_operators()
-    
-    # Unregister properties
-    from ..properties import unregister_properties
-    unregister_properties()
-    
-    # Unregister icons last
-    from ..icons import unregister_icons
-    unregister_icons()
+    """Unregister all components of the addon in reverse order."""
+    for module_name, _, unregister_func in reversed(COMPONENTS):
+        module = import_module(module_name, __package__)
+        getattr(module, unregister_func)()


### PR DESCRIPTION
## Summary
- centralize component registration using a table-driven approach
- streamline property registration with a pointer mapping
- break out helpers for mirroring bone keyframes

## Testing
- `python3 - <<'EOF'
import py_compile, pathlib, sys
for file in pathlib.Path('.').rglob('*.py'):
    try:
        py_compile.compile(str(file), doraise=True)
    except Exception as e:
        print('Failed:', file, e)
        sys.exit(1)
print('py_compile success')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685d669d5a4483298aad9688646fcf84