### PR TITLE
Fix preference refresh for custom tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Blender animation helper addon that provides a collection of tools to streamli
 ## Features
 
 ### Space Switching Tools
+The main panel now groups its sections into collapsible subpanels so you can hide tools you use less often.
 - **Knot**: Creates an empty object to control a pose bone or object with constraints
 - **Shoulder Lock**: Creates rotation-locked controls for shoulder bones in FK chains
 - **Copy Transforms**: Creates empties that copy transforms from bones for advanced animation control
@@ -38,7 +39,7 @@ A Blender animation helper addon that provides a collection of tools to streamli
 
 ## Usage
 
-After installation, the tools can be found in the 3D View sidebar under the "AH Helper" tab.
+After installation, the tools appear in the 3D View sidebar. The tab label can be changed from **Add-on Preferences → Tab Name** (defaults to "AH Helper").
 
 ### Animation Workflow Tips
 

--- a/addon/operators/Offset.py
+++ b/addon/operators/Offset.py
@@ -5,6 +5,7 @@ class AH_offset(bpy.types.Operator):
     """Create manipulator empty system for controlling animated objects"""
     bl_idname = "object.setup_manipulator"
     bl_label = "Setup Manipulator"
+    bl_description = "Create an empty at the cursor and parent it to the active object"
     bl_options = {'REGISTER', 'UNDO'}
 
 

--- a/addon/operators/animation_bake.py
+++ b/addon/operators/animation_bake.py
@@ -1,48 +1,4 @@
 import bpy
-import bpy.props
-
-class AH_BakeProperties(bpy.types.PropertyGroup):
-    """Property group for animation baking settings"""
-    smart_bake: bpy.props.BoolProperty(
-        name="Smart Bake", 
-        default=True, 
-        description="Automatically detect keyframe range for baking"
-    )
-    custom_frame_start: bpy.props.IntProperty(
-        name="Custom Start Frame", 
-        default=1, 
-        description="Specify start frame for baking"
-    )
-    custom_frame_end: bpy.props.IntProperty(
-        name="Custom End Frame", 
-        default=250, 
-        description="Specify end frame for baking"
-    )
-    only_selected_bones: bpy.props.BoolProperty(
-        name="Only Selected Bones", 
-        default=True,
-        description="Only bake selected bones"
-    )
-    visual_keying: bpy.props.BoolProperty(
-        name="Visual Keying", 
-        default=True,
-        description="Use visual keying for baking"
-    )
-    clear_constraints: bpy.props.BoolProperty(
-        name="Clear Constraints", 
-        default=True,
-        description="Remove constraints after baking"
-    )
-    clear_parents: bpy.props.BoolProperty(
-        name="Clear Parents", 
-        default=True,
-        description="Clear parent relationship after baking"
-    )
-    overwrite_current_action: bpy.props.BoolProperty(
-        name="Overwrite Current Action", 
-        default=True,
-        description="Use existing action instead of creating a new one"
-    )
 
 class AH_AnimationBake(bpy.types.Operator):
     """Bake animations for selected objects and bones with advanced options"""

--- a/addon/operators/offset_cleanup.py
+++ b/addon/operators/offset_cleanup.py
@@ -5,6 +5,7 @@ class AH_offset_cleanup(bpy.types.Operator):
     """Clean up manipulator empty system by removing empties and constraint"""
     bl_idname = "object.cleanup_manipulator"
     bl_label = "Cleanup Manipulator"
+    bl_description = "Remove helper empties and related constraints"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod

--- a/addon/preferences/__init__.py
+++ b/addon/preferences/__init__.py
@@ -1,0 +1,51 @@
+import bpy
+
+ROOT_MODULE = __package__.split('.')[0]
+
+
+class AH_AddonPreferences(bpy.types.AddonPreferences):
+    bl_idname = ROOT_MODULE
+
+    tab_name: bpy.props.StringProperty(
+        name="Tab Name",
+        description="Name of the sidebar tab where panels appear",
+        default="AH Helper",
+        update=lambda self, context: refresh_panel_categories()
+    )
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(self, "tab_name")
+
+
+def update_panel_categories():
+    """Update the bl_category for all registered panels"""
+    import importlib
+    ui_module = importlib.import_module(f"{ROOT_MODULE}.addon.ui")
+    prefs = bpy.context.preferences.addons[ROOT_MODULE].preferences
+    for cls in ui_module.classes:
+        cls.bl_category = prefs.tab_name
+
+
+def refresh_panel_categories():
+    """Reload UI panels so category changes take effect immediately"""
+    import importlib
+    from bpy.utils import unregister_class, register_class
+    ui_module = importlib.import_module(f"{ROOT_MODULE}.addon.ui")
+    prefs = bpy.context.preferences.addons[ROOT_MODULE].preferences
+    for cls in ui_module.classes:
+        try:
+            unregister_class(cls)
+        except Exception:
+            pass
+        cls.bl_category = prefs.tab_name
+        register_class(cls)
+
+
+def register_preferences():
+    bpy.utils.register_class(AH_AddonPreferences)
+    update_panel_categories()
+
+def unregister_preferences():
+    bpy.utils.unregister_class(AH_AddonPreferences)
+

--- a/addon/register/__init__.py
+++ b/addon/register/__init__.py
@@ -14,6 +14,10 @@ def register_addon():
     from ..operators import register_operators
     register_operators()
 
+    # Register addon preferences
+    from ..preferences import register_preferences
+    register_preferences()
+
     # Register UI panels
     from ..ui import register_panels
     register_panels()
@@ -23,6 +27,10 @@ def unregister_addon():
     # Unregister UI panels first
     from ..ui import unregister_panels
     unregister_panels()
+
+    # Unregister addon preferences
+    from ..preferences import unregister_preferences
+    unregister_preferences()
 
     # Unregister operators
     from ..operators import unregister_operators
@@ -35,3 +43,4 @@ def unregister_addon():
     # Unregister icons last
     from ..icons import unregister_icons
     unregister_icons()
+

--- a/addon/ui/__init__.py
+++ b/addon/ui/__init__.py
@@ -1,18 +1,23 @@
 import bpy
 
 # Import panels with updated class names
-from .panel1 import AH_AnimTools
+from .panel1 import AH_AnimTools, AH_PT_SpaceSwitching, AH_PT_KeyframeCleanup, AH_PT_AnimationBaking, AH_PT_AnimToolsHelp
 from .panel2 import AH_MaterialTools
 from .panel_action_management import AH_ActionManagement
 from .panel_facial_auto import AH_FacialAutoProcessingPanel
 from.panel_nla_transfer import AH_NLATransferPanel
 from.panel_nla_smoothing import AH_NLASmoothingPanel
 from .panel_audio_nla_consolidation import AH_AudioNLAConsolidationPanel
+from ..preferences import update_panel_categories
 
 # Add panels to classes array
 classes = (
     AH_MaterialTools,
     AH_AnimTools,
+    AH_PT_SpaceSwitching,
+    AH_PT_KeyframeCleanup,
+    AH_PT_AnimationBaking,
+    AH_PT_AnimToolsHelp,
     AH_ActionManagement,
     AH_FacialAutoProcessingPanel,
     AH_NLATransferPanel,
@@ -23,6 +28,7 @@ classes = (
 def register_panels():
     """Register all panel classes"""
     from bpy.utils import register_class
+    update_panel_categories()
     for cls in classes:
         register_class(cls)
 

--- a/addon/ui/panel1.py
+++ b/addon/ui/panel1.py
@@ -30,30 +30,28 @@ except ImportError:
 
 
 class AH_AnimTools(bpy.types.Panel):
-    """Animation tools panel in the 3D View sidebar"""
+    """Root panel for animation tools"""
     bl_label = "Anim Tools"
     bl_idname = "AH_PT_AnimTools"
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category = 'AH Helper'
-    
+
+    def draw(self, context):
+        self.layout.label(text="Tools for animation workflow")
+
+class AH_PT_SpaceSwitching(bpy.types.Panel):
+    bl_label = "Space Switching"
+    bl_idname = "AH_PT_SpaceSwitching"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'AH Helper'
+    bl_parent_id = "AH_PT_AnimTools"
+    bl_options = {'DEFAULT_CLOSED'}
+
     def draw(self, context):
         layout = self.layout
-        scene = context.scene
-        bakeprops = scene.bprops
-        
-        # Space Switching Tools section
         self.draw_space_switching_section(layout)
-        
-        layout.separator()
-        
-        # Keyframe cleanup section
-        self.draw_keyframe_cleanup_section(layout, scene)
-        
-        layout.separator()
-        
-        # Animation baking section
-        self.draw_animation_baking_section(layout, bakeprops)
 
     def draw_space_switching_section(self, layout):
         """Draw the space switching tools section with original layout"""
@@ -109,55 +107,89 @@ class AH_AnimTools(bpy.types.Panel):
         row.operator(AH_OT_EmptySizeGrow.bl_idname, icon='ADD', text="+")
         row.operator(AH_OT_EmptySizeShrink.bl_idname, icon='REMOVE', text="-")
 
-    def draw_keyframe_cleanup_section(self, layout, scene):
-        """Draw the keyframe cleanup section with original layout"""
+class AH_PT_KeyframeCleanup(bpy.types.Panel):
+    bl_label = "Keyframe Cleanup"
+    bl_idname = "AH_PT_KeyframeCleanup"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'AH Helper'
+    bl_parent_id = "AH_PT_AnimTools"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene
+
         box = layout.box()
         box.label(text="Keyframe Cleanup")
-        
-        # Decimate Keyframes button
+
         row = box.row()
         row.operator(AH_DecimateKeys.bl_idname, icon='COLORSET_02_VEC', text="Decimate Keyframes")
-        
-        # Decimate Factor slider
+
         row = box.row()
         row.prop(scene, "Factor", slider=True)
+class AH_PT_AnimationBaking(bpy.types.Panel):
+    bl_label = "Animation Baking"
+    bl_idname = "AH_PT_AnimationBaking"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'AH Helper'
+    bl_parent_id = "AH_PT_AnimTools"
+    bl_options = {'DEFAULT_CLOSED'}
 
-    def draw_animation_baking_section(self, layout, bakeprops):
-        """Draw the animation baking section with original layout"""
+    def draw(self, context):
+        layout = self.layout
+        bakeprops = context.scene.bprops
+
         box = layout.box()
         box.label(text="Animation Baking")
-        
-        # Easy Bake Animation button (in alert/red style)
+
         row = box.row()
         row.alert = True
         row.operator(AH_AnimationBake.bl_idname, icon='REC', text="Easy Bake Animation")
-        
-        # Duplicate Selected Bones Action button
+
         row = box.row()
         row.operator(AH_DuplicateSelectedBonesAction.bl_idname, icon='COLORSET_09_VEC', text="Duplicate Selected Bones Action")
-        
-        # Baking Options section (collapsible)
+
         box.prop(bakeprops, "smart_bake", text="Smart Bake")
-        
+
         if not bakeprops.smart_bake:
             row = box.row(align=True)
             row.prop(bakeprops, "custom_frame_start", text="Start")
             row.prop(bakeprops, "custom_frame_end", text="End")
-        
-        # Keying Options subsection
+
         box.label(text="Keying Options:")
         col = box.column(align=True)
         col.prop(bakeprops, "visual_keying")
         col.prop(bakeprops, "only_selected_bones")
-        
-        # Cleanup Options subsection
+
         box.label(text="Cleanup Options:")
         col = box.column(align=True)
         col.prop(bakeprops, "clear_constraints")
         col.prop(bakeprops, "clear_parents")
         col.prop(bakeprops, "overwrite_current_action")
 
+class AH_PT_AnimToolsHelp(bpy.types.Panel):
+    bl_label = "Help"
+    bl_idname = "AH_PT_AnimToolsHelp"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'AH Helper'
+    bl_parent_id = "AH_PT_AnimTools"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        box = layout.box()
+        box.label(text="Tips:")
+        col = box.column(align=True)
+        col.label(text="- Use Smart Bake for auto frame range")
+        col.label(text="- Cleanup removes constraints after baking")
+        col.label(text="- Change tab name in add-on prefs")
+
     def draw_header(self, context):
         """Draw panel header with icon"""
         layout = self.layout
         layout.label(icon='ARMATURE_DATA')
+
+

--- a/addon/ui/panel_action_management.py
+++ b/addon/ui/panel_action_management.py
@@ -14,7 +14,7 @@ class AH_ActionManagement(bpy.types.Panel):
     bl_idname = "AH_PT_ActionManagement"
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_category = 'Animation'
+    bl_category = 'AH Helper'
     
     def draw(self, context):
         layout = self.layout


### PR DESCRIPTION
## Summary
- reload panels when tab name preference changes
- set panel categories before registration
- clarify README usage instructions
- remove duplicate bake property group to avoid registration errors

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'not_reg')`


------
https://chatgpt.com/codex/tasks/task_e_685d66acf8808329a588cea2dafa698a